### PR TITLE
Upgrade to Resonate SDK v0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ vite.config.ts.timestamp-*
 .cursor
 resonate.db
 bun.lock
+package-lock.json

--- a/client.ts
+++ b/client.ts
@@ -1,7 +1,8 @@
 import { Resonate } from "@resonatehq/sdk";
 import { v4 as uuid } from "uuid";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "http://localhost:8001",
   group: "client",
 });
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@resonatehq/sdk": ">=0.8.0",
+    "@resonatehq/sdk": "^0.10.0",
     "uuid": "^11.1.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,17 @@
 {
   "compilerOptions": {
-    // Environment setup & latest features
     "lib": ["ESNext"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
-
-    // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
-
-    // Best practices
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+    "noImplicitOverride": true
   }
 }

--- a/worker.ts
+++ b/worker.ts
@@ -1,7 +1,8 @@
 import { Resonate } from "@resonatehq/sdk";
 import type { Context } from "@resonatehq/sdk";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "http://localhost:8001",
   group: "workers",
 });
 


### PR DESCRIPTION
## Summary

- Upgrades to Resonate SDK v0.10.0
- Updates dependencies and source files accordingly

## Test plan

- [ ] Build passes
- [ ] Example runs as expected with Resonate SDK v0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)